### PR TITLE
Update MySql integration to use Pooling connections

### DIFF
--- a/src/loaders/dependencyInjector.js
+++ b/src/loaders/dependencyInjector.js
@@ -1,10 +1,10 @@
 const Container = require('typedi').Container;
 const loggerInstance = require('./logger');
 
-async function dependencyInjectorSetUp(mySqlConnection) {
+async function dependencyInjectorSetUp(mySqlPool) {
   try {
     Container.set('logger', loggerInstance);
-    Container.set('mySqlConnection', mySqlConnection);
+    Container.set('mySqlPool', mySqlPool);
   } catch (err) {
     loggerInstance.error('🔥 Error on dependency injector loader: %o', err);
     throw err;

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -5,11 +5,11 @@ async function loader(expressApp) {
   const logger = require('./logger');
   logger.info('📝 Logger is loaded');
 
-  const mySqlConnection = await require('./mySql');
+  const mySqlPool = await require('./mySql');
   logger.info('📊 MySQL DB Loaded and Ready');
 
   const dependencyInjectorSetUp = await require('./dependencyInjector');
-  dependencyInjectorSetUp(mySqlConnection);
+  dependencyInjectorSetUp(mySqlPool);
   logger.info('💉 Dependency Injector Loaded and Ready');
 
   const expressSetUp = await require('./express');

--- a/src/loaders/mySql.js
+++ b/src/loaders/mySql.js
@@ -2,38 +2,14 @@
 
 const mysql = require('mysql');
 const config = require('../config');
-const logger = require('./logger');
 
-let connection;
+const pool = mysql.createPool({
+  connectionLimit: 100,
+  host: config.DB_HOST,
+  user: config.DB_USER,
+  password: config.DB_PASSWORD,
+  database: config.DB_NAME,
+});
 
-function handleConnection() {
-  connection = mysql.createConnection({
-    host: config.DB_HOST,
-    user: config.DB_USER,
-    password: config.DB_PASSWORD,
-    database: config.DB_NAME,
-  });
 
-  connection.connect((err) => {
-    if (err) {
-      return logger.error(`error: ${err.message}`);
-    }
-
-    return logger.info('🔗 Connected to the MySQL server.');
-  });
-
-  // Heroku seems to disconnect with MySql often
-  // Handle these disconnections by reconnecting with the DB
-  connection.on('error', ((err) => {
-    logger.error('db error', err);
-    if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-      handleConnection();
-    } else {
-      throw err;
-    }
-  }));
-}
-
-handleConnection();
-
-module.exports = connection;
+module.exports = pool;

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const Container = require('typedi').Container;
 
-const mySqlConnection = Container.get('mySqlConnection');
+const mySqlPool = Container.get('mySqlPool');
 const logger = Container.get('logger');
 const config = require('../config');
 
@@ -48,7 +48,7 @@ function generateToken(user, today) {
 
 function dbQueryForUser(email, password) {
   return new Promise(((resolve, reject) => {
-    mySqlConnection.query('SELECT * FROM users WHERE email = ? ', email, (err, res) => {
+    mySqlPool.query('SELECT * FROM users WHERE email = ? ', email, (err, res) => {
       if (res.length < 1) {
         reject(new Error('❌ Could not verify email'));
       } else {
@@ -72,7 +72,7 @@ function dbQueryForUser(email, password) {
 
 function dbInsertNewUser(newUserParams) {
   return new Promise(((resolve, reject) => {
-    mySqlConnection.query('INSERT INTO users SET ?', newUserParams, (err, res) => {
+    mySqlPool.query('INSERT INTO users SET ?', newUserParams, (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong while trying to create your account: ${err.message}`));
       } else {

--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -1,6 +1,6 @@
 const Container = require('typedi').Container;
 
-const mySqlConnection = Container.get('mySqlConnection');
+const mySqlPool = Container.get('mySqlPool');
 const logger = Container.get('logger');
 // const runnerService = require('./runnerJobs');
 
@@ -14,7 +14,7 @@ const logger = Container.get('logger');
 
 function dbGetOrdersByIds(ids) {
   return new Promise((resolve, reject) => {
-    mySqlConnection.query('SELECT * FROM orders WHERE id IN (?) ', [ids], (err, res) => {
+    mySqlPool.query('SELECT * FROM orders WHERE id IN (?) ', [ids], (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong when querying for orders: ${err.message}`));
       } else {
@@ -26,7 +26,7 @@ function dbGetOrdersByIds(ids) {
 
 function dbCreateNewOrder(newOrderParams) {
   return new Promise((resolve, reject) => {
-    mySqlConnection.query('INSERT INTO orders SET ? ', newOrderParams, (err, res) => {
+    mySqlPool.query('INSERT INTO orders SET ? ', newOrderParams, (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong when trying to create the new order: ${err.message}`));
       } else {
@@ -40,7 +40,7 @@ function dbCreateNewOrder(newOrderParams) {
 
 function dbUpdateOrderWithRunnerInfo(runnerInfo, orderId) {
   return new Promise((resolve, reject) => {
-    mySqlConnection.query('UPDATE orders SET ? WHERE id = ? ', [runnerInfo, orderId], (err, res) => {
+    mySqlPool.query('UPDATE orders SET ? WHERE id = ? ', [runnerInfo, orderId], (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong when trying to assign the order to the runner: ${err.message}`));
       } else {

--- a/src/services/runnerJobs.js
+++ b/src/services/runnerJobs.js
@@ -1,7 +1,7 @@
 const Container = require('typedi').Container;
 const { Client, Status } = require('@googlemaps/google-maps-services-js'); // TO DO: Move this to dependencyInjector
 
-const mySqlConnection = Container.get('mySqlConnection');
+const mySqlPool = Container.get('mySqlPool');
 const logger = Container.get('logger');
 
 const config = require('../config');
@@ -10,7 +10,7 @@ const client = new Client({});
 
 function dbCreateNewRunnerJob(newRunnerJobParams) {
   return new Promise(((resolve, reject) => {
-    mySqlConnection.query('INSERT INTO runner_jobs SET ? ', newRunnerJobParams, (err, res) => {
+    mySqlPool.query('INSERT INTO runner_jobs SET ? ', newRunnerJobParams, (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong when trying to create the runner job: ${err.message}`));
       } else {
@@ -27,7 +27,7 @@ function dbGetActiveRunnerJobs() {
   const status = 'ACTIVE';
   const isAcceptingRequests = true;
   return new Promise(((resolve, reject) => {
-    mySqlConnection.query('SELECT * FROM runner_jobs WHERE status = ? AND is_accepting_requests = ?', [status, isAcceptingRequests], (err, res) => {
+    mySqlPool.query('SELECT * FROM runner_jobs WHERE status = ? AND is_accepting_requests = ?', [status, isAcceptingRequests], (err, res) => {
       if (err) {
         reject(new Error(`❌ Something went wrong when querying for runner job: ${err.message}`));
       } else {


### PR DESCRIPTION
**Motivation/problem:**
Right now in production environment, errand crashes every few minutes with this fatal error:

> "msg":"db error Error: Connection lost: The server closed the connection.\n
> fatal: true,\n  code: 'PROTOCOL_CONNECTION_LOST'

It appears every few minutes that errand loses connection briefly with the remote MySQL database (CloudDB), and once this happens node-mysql does not allow you to run any queries until the connection is restarted

**Solution:**

Rather than creating and managing connections one-by-one, we can use the built in node-mysql connection pooling module (mySql.createPool(poolConfig)). Connection pooling means  that we keep a cache of database connections maintained so that the connections can be reused when future requests to the database are required. Connections will only be created and used when a query occurs, and after the query completes (successful or not), the connection released back into the pool. You can read more about it here: https://en.wikipedia.org/wiki/Connection_pool 

By using connection pooling to create and use connection with the remote CloudDB DB only when we need to make a query and then releasing the connection right after, rather than maintaining one connection always, we should limit/eliminate the number of 'Connection lost' errors we are seeing.

I have tested and linted this change. All 15 integration tests passed successfully